### PR TITLE
Update VSCode settings and add clippy checks in Rust modules

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,8 +3,10 @@
     ".git/**/*",
     ".vscode",
     "target/**/*",
+    "opc_da_bindings/.metadata/**/*",
     "opc_da_bindings/src/bindings.rs"
   ],
+  "cSpell.spellCheckOnlyWorkspaceFiles": true,
   "cSpell.words": [
     "bindgen",
     "BSTR",
@@ -13,6 +15,7 @@
     "CLSID",
     "COINIT",
     "Comn",
+    "CONNECTDATA",
     "enumer",
     "globset",
     "HRESULT",
@@ -64,5 +67,6 @@
     "**/.settings": true,
     "**/.factorypath": true
   },
-  "hide-files.files": []
+  "hide-files.files": [],
+  "rust-analyzer.check.command": "clippy"
 }

--- a/opc_da/src/lib.rs
+++ b/opc_da/src/lib.rs
@@ -6,9 +6,12 @@ pub mod builder;
 pub mod client;
 pub mod connection_point;
 pub mod core;
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub mod enumeration;
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub mod group;
 pub mod item;
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub mod server;
 pub mod utils;
 pub mod variant;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added spell checker settings to ignore specific paths and limit checks to workspace files.
	- Expanded recognized spell-check words with "CONNECTDATA."
	- Introduced a command for Rust code checking using Clippy.

- **Bug Fixes**
	- Suppressed specific Clippy warnings for certain modules, enhancing code quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->