### PR TITLE
Bump opc_da_bindings version to 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,7 @@ dependencies = [
 
 [[package]]
 name = "opc_da_bindings"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "windows",
  "windows-bindgen",

--- a/opc_da_bindings/Cargo.toml
+++ b/opc_da_bindings/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "opc_da_bindings"
 description = "OPC Data Access bindings"
-version = "0.1.1"
+version = "0.1.2"
 license = "MIT"
 edition = "2021"
 repository = "https://github.com/Ronbb/rust_opc"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version number of the `opc_da_bindings` package from 0.1.1 to 0.1.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->