### PR TITLE
Enhance Memory Management and Update ClientTrait in OPC DA Client

### DIFF
--- a/opc_da/src/client/memory.rs
+++ b/opc_da/src/client/memory.rs
@@ -99,7 +99,7 @@ impl<T: Sized> RemoteArray<T> {
     /// # Safety
     /// The caller must ensure that the new length is valid for the underlying array.
     #[inline(always)]
-    pub(crate) fn set_len(&mut self, len: u32) {
+    pub(crate) unsafe fn set_len(&mut self, len: u32) {
         self.len = len;
     }
 }

--- a/opc_da/src/client/memory.rs
+++ b/opc_da/src/client/memory.rs
@@ -160,9 +160,17 @@ impl<T: Sized> RemotePointer<T> {
     /// # Safety
     /// The caller must ensure that the inner pointer is valid for reads.
     #[inline(always)]
-    pub fn as_option(&self) -> Option<&T> {
+    pub fn as_ref(&self) -> Option<&T> {
         // Pointer is guaranteed to be valid
         unsafe { self.inner.as_ref() }
+    }
+
+    #[inline(always)]
+    pub fn as_result(&self) -> windows::core::Result<&T> {
+        // Pointer is guaranteed to be valid
+        unsafe { self.inner.as_ref() }.ok_or_else(|| {
+            windows::core::Error::new(windows::Win32::Foundation::E_POINTER, "Pointer is null")
+        })
     }
 }
 

--- a/opc_da/src/client/mod.rs
+++ b/opc_da/src/client/mod.rs
@@ -7,13 +7,16 @@
 //! - A unified client interface in the `unified` module
 //! - Common traits and memory management utilities
 
+mod iterator;
 mod memory;
 mod traits;
+
 pub mod unified;
 pub mod v1;
 pub mod v2;
 pub mod v3;
 
+pub use iterator::*;
 pub use memory::*;
 pub use traits::*;
 

--- a/opc_da/src/client/tests.rs
+++ b/opc_da/src/client/tests.rs
@@ -6,7 +6,7 @@ use super::*;
 
 #[test]
 fn test_client() {
-    let client = Guard::new(unified::Client::V2).expect("Failed to create guard");
+    let client = Guard::new(unified::Client::v2()).expect("Failed to create guard");
 
     let servers = client
         .get_servers()

--- a/opc_da/src/client/tests.rs
+++ b/opc_da/src/client/tests.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use unified::{Guard, Server, StringIterator};
+use unified::{Guard, Server};
 
 use super::*;
 
@@ -68,8 +68,20 @@ fn test_client() {
 
     println!("Item name: {:?}", name);
 
+    let mut group_server_handle = 0u32;
+    let mut revised_percent_deadband = 0u32;
     let group = server
-        .add_group("test", true, 0, 0, 0, 0, 0.0)
+        .add_group(
+            "test",
+            true,
+            0,
+            0,
+            0,
+            0,
+            0.0,
+            &mut revised_percent_deadband,
+            &mut group_server_handle,
+        )
         .expect("Failed to add group");
 
     let name = LocalPointer::from_str(&name).expect("Failed to convert name");

--- a/opc_da/src/client/traits/browse.rs
+++ b/opc_da/src/client/traits/browse.rs
@@ -106,7 +106,7 @@ pub trait BrowseTrait {
         }
 
         if count > 0 {
-            elements.set_len(count);
+            unsafe { elements.set_len(count) };
         }
 
         Ok((more_elements.into(), elements))

--- a/opc_da/src/client/traits/client.rs
+++ b/opc_da/src/client/traits/client.rs
@@ -1,6 +1,6 @@
 use windows_core::Interface as _;
 
-use crate::client::unified::GuidIterator;
+use crate::client::GuidIterator;
 
 /// Trait defining client functionality for OPC Data Access servers.
 pub trait ClientTrait<Server: TryFrom<windows::core::IUnknown, Error = windows::core::Error>> {

--- a/opc_da/src/client/traits/client.rs
+++ b/opc_da/src/client/traits/client.rs
@@ -1,0 +1,63 @@
+use windows_core::Interface as _;
+
+use crate::client::unified::GuidIterator;
+
+/// Trait defining client functionality for OPC Data Access servers.
+pub trait ClientTrait<Server: TryFrom<windows::core::IUnknown, Error = windows::core::Error>> {
+    /// GUID of the catalog used to enumerate servers.
+    const CATALOG_ID: windows::core::GUID;
+
+    /// Retrieves an iterator over available server GUIDs.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing a `GuidIterator` over server GUIDs, or an error if the operation fails.
+    fn get_servers(&self) -> windows::core::Result<GuidIterator> {
+        let id = unsafe {
+            windows::Win32::System::Com::CLSIDFromProgID(windows::core::w!("OPC.ServerList.1"))?
+        };
+
+        let servers: opc_da_bindings::IOPCServerList = unsafe {
+            // TODO: Use CoCreateInstanceEx
+            windows::Win32::System::Com::CoCreateInstance(
+                &id,
+                None,
+                // TODO: Convert from filters
+                windows::Win32::System::Com::CLSCTX_ALL,
+            )?
+        };
+
+        let versions = [Self::CATALOG_ID];
+
+        let iter = unsafe {
+            servers
+                .EnumClassesOfCategories(&versions, &versions)
+                .map_err(|e| {
+                    windows::core::Error::new(e.code(), "Failed to enumerate server classes")
+                })?
+        };
+
+        Ok(GuidIterator::new(iter))
+    }
+
+    /// Creates a server instance from the specified class ID.
+    ///
+    /// # Parameters
+    ///
+    /// - `class_id`: The GUID of the server class to instantiate.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing the server instance, or an error if creation fails.
+    fn create_server(&self, class_id: windows::core::GUID) -> windows::core::Result<Server> {
+        let server: opc_da_bindings::IOPCServer = unsafe {
+            windows::Win32::System::Com::CoCreateInstance(
+                &class_id,
+                None,
+                windows::Win32::System::Com::CLSCTX_ALL,
+            )?
+        };
+
+        server.cast::<windows::core::IUnknown>()?.try_into()
+    }
+}

--- a/opc_da/src/client/traits/group_state_mgt.rs
+++ b/opc_da/src/client/traits/group_state_mgt.rs
@@ -54,7 +54,7 @@ pub trait GroupStateMgtTrait {
     /// * `time_bias` - Time bias from UTC in minutes
     /// * `percent_deadband` - Percent deadband for analog items
     /// * `locale_id` - Locale ID for status/error strings
-    /// * `client_group_handle` - Client-provided handle
+    /// * `client_handle` - Client-provided handle
     ///
     /// # Returns
     /// The actual update rate set by the server
@@ -65,7 +65,7 @@ pub trait GroupStateMgtTrait {
         time_bias: Option<i32>,
         percent_deadband: Option<f32>,
         locale_id: Option<u32>,
-        client_group_handle: Option<u32>,
+        client_handle: Option<u32>,
     ) -> windows::core::Result<u32> {
         let requested_update_rate = LocalPointer::new(update_rate);
         let mut revised_update_rate = LocalPointer::new(Some(0));
@@ -73,7 +73,7 @@ pub trait GroupStateMgtTrait {
         let time_bias = LocalPointer::new(time_bias);
         let percent_deadband = LocalPointer::new(percent_deadband);
         let locale_id = LocalPointer::new(locale_id);
-        let client_group_handle = LocalPointer::new(client_group_handle);
+        let client_handle = LocalPointer::new(client_handle);
 
         unsafe {
             self.interface()?.SetState(
@@ -83,7 +83,7 @@ pub trait GroupStateMgtTrait {
                 time_bias.as_ptr(),
                 percent_deadband.as_ptr(),
                 locale_id.as_ptr(),
-                client_group_handle.as_ptr(),
+                client_handle.as_ptr(),
             )
         }?;
 

--- a/opc_da/src/client/traits/group_state_mgt.rs
+++ b/opc_da/src/client/traits/group_state_mgt.rs
@@ -33,8 +33,8 @@ pub trait GroupStateMgtTrait {
                     &mut state.time_bias,
                     &mut state.percent_deadband,
                     &mut state.locale_id,
-                    &mut state.client_group_handle,
-                    &mut state.server_group_handle,
+                    &mut state.client_handle,
+                    &mut state.server_handle,
                 )?;
             }
             name

--- a/opc_da/src/client/traits/item_properties.rs
+++ b/opc_da/src/client/traits/item_properties.rs
@@ -56,9 +56,11 @@ pub trait ItemPropertiesTrait {
         }
 
         if count > 0 {
-            property_ids.set_len(count);
-            descriptions.set_len(count);
-            datatypes.set_len(count);
+            unsafe {
+                property_ids.set_len(count);
+                descriptions.set_len(count);
+                datatypes.set_len(count);
+            }
         }
 
         Ok((property_ids, descriptions, datatypes))

--- a/opc_da/src/client/traits/mod.rs
+++ b/opc_da/src/client/traits/mod.rs
@@ -1,3 +1,8 @@
+mod async_io;
+mod async_io2;
+mod async_io3;
+mod browse;
+mod browse_server_address_space;
 /// OPC DA client trait definitions.
 ///
 /// This module contains all trait definitions for interacting with OPC DA servers.
@@ -24,11 +29,7 @@
 /// - ItemIoTrait: Direct item access
 /// - ItemSamplingMgtTrait: Sampling rate control
 /// - GroupStateMgt2Trait: Extended group management
-mod async_io;
-mod async_io2;
-mod async_io3;
-mod browse;
-mod browse_server_address_space;
+mod client;
 mod common;
 mod connection_point_container;
 mod data_object;
@@ -50,6 +51,7 @@ pub use async_io2::*;
 pub use async_io3::*;
 pub use browse::*;
 pub use browse_server_address_space::*;
+pub use client::*;
 pub use common::*;
 pub use connection_point_container::*;
 pub use data_object::*;

--- a/opc_da/src/client/traits/server.rs
+++ b/opc_da/src/client/traits/server.rs
@@ -6,11 +6,8 @@ use crate::client::{LocalPointer, RemotePointer};
 ///
 /// Provides methods to create and manage groups within an OPC server,
 /// as well as monitor server status and enumerate existing groups.
-pub trait ServerTrait<Group> {
+pub trait ServerTrait<Group: TryFrom<windows::core::IUnknown, Error = windows::core::Error>> {
     fn interface(&self) -> windows::core::Result<&opc_da_bindings::IOPCServer>;
-
-    /// Creates a group wrapper from a COM interface.
-    fn create_group(&self, unknown: windows::core::IUnknown) -> windows::core::Result<Group>;
 
     /// Adds a new group to the OPC server.
     ///
@@ -66,7 +63,7 @@ pub trait ServerTrait<Group> {
                 windows::Win32::Foundation::E_POINTER,
                 "Failed to add group, returned null",
             )),
-            Some(group) => self.create_group(group),
+            Some(group) => group.cast::<windows::core::IUnknown>()?.try_into(),
         }
     }
 

--- a/opc_da/src/client/unified/actor/client.rs
+++ b/opc_da/src/client/unified/actor/client.rs
@@ -1,10 +1,7 @@
 use actix::prelude::*;
 
 use crate::{
-    client::{
-        unified::{Client, GuidIterator},
-        RemotePointer,
-    },
+    client::{unified::Client, GuidIterator, RemotePointer},
     mb_error,
 };
 

--- a/opc_da/src/client/unified/actor/tests.rs
+++ b/opc_da/src/client/unified/actor/tests.rs
@@ -5,7 +5,7 @@ use super::ClientActor;
 #[test]
 fn test_actor() {
     actix::System::with_tokio_rt(create_runtime).block_on(async {
-        let client = ClientActor::new(Client::V2).expect("Failed to create client actor");
+        let client = ClientActor::new(Client::v2()).expect("Failed to create client actor");
         let servers = client.get_servers().await.expect("Failed to get servers");
 
         assert!(!servers.is_empty());

--- a/opc_da/src/client/unified/client.rs
+++ b/opc_da/src/client/unified/client.rs
@@ -1,6 +1,6 @@
-use crate::client::{v1, v2, v3, ClientTrait as _};
+use crate::client::{v1, v2, v3, ClientTrait as _, GuidIterator};
 
-use super::{GuidIterator, Server};
+use super::Server;
 
 #[derive(Debug)]
 pub enum Client {
@@ -36,5 +36,23 @@ impl Client {
             Client::V2(client) => Ok(Server::V2(client.create_server(class_id)?)),
             Client::V3(client) => Ok(Server::V3(client.create_server(class_id)?)),
         }
+    }
+}
+
+impl From<v1::Client> for Client {
+    fn from(client: v1::Client) -> Self {
+        Self::V1(client)
+    }
+}
+
+impl From<v2::Client> for Client {
+    fn from(client: v2::Client) -> Self {
+        Self::V2(client)
+    }
+}
+
+impl From<v3::Client> for Client {
+    fn from(client: v3::Client) -> Self {
+        Self::V3(client)
     }
 }

--- a/opc_da/src/client/unified/group.rs
+++ b/opc_da/src/client/unified/group.rs
@@ -1,6 +1,6 @@
 use crate::{
     client::{v1, v2, v3, ItemMgtTrait},
-    def::{IntoBridge as _, ItemDef, ItemResult, ToNative as _, TryFromNative as _},
+    def::{IntoBridge as _, ItemDef, ItemResult, TryFromNative as _, TryToNative as _},
 };
 
 pub enum Group {
@@ -23,8 +23,8 @@ impl Group {
         &self,
         items: Vec<ItemDef>,
     ) -> windows::core::Result<Vec<windows::core::Result<ItemResult>>> {
-        let mut bridge = items.into_bridge();
-        let (results, errors) = self.item_mgt().add_items(&bridge.to_native()?)?;
+        let bridge = items.into_bridge();
+        let (results, errors) = self.item_mgt().add_items(&bridge.try_to_native()?)?;
         Ok(results
             .as_slice()
             .iter()

--- a/opc_da/src/client/unified/group.rs
+++ b/opc_da/src/client/unified/group.rs
@@ -39,3 +39,21 @@ impl Group {
             .collect())
     }
 }
+
+impl From<v1::Group> for Group {
+    fn from(group: v1::Group) -> Self {
+        Self::V1(group)
+    }
+}
+
+impl From<v2::Group> for Group {
+    fn from(group: v2::Group) -> Self {
+        Self::V2(group)
+    }
+}
+
+impl From<v3::Group> for Group {
+    fn from(group: v3::Group) -> Self {
+        Self::V3(group)
+    }
+}

--- a/opc_da/src/client/unified/mod.rs
+++ b/opc_da/src/client/unified/mod.rs
@@ -2,12 +2,10 @@ pub mod actor;
 pub mod client;
 pub mod group;
 pub mod guard;
-pub mod iter;
 pub mod server;
 
 pub use actor::*;
 pub use client::*;
 pub use group::*;
 pub use guard::*;
-pub use iter::*;
 pub use server::*;

--- a/opc_da/src/client/unified/server.rs
+++ b/opc_da/src/client/unified/server.rs
@@ -1,7 +1,112 @@
-use crate::client::{v1, v2, v3};
+use crate::{
+    client::{v1, v2, v3, ServerTrait as _},
+    def::{self, TryFromNative},
+};
+
+use super::Group;
 
 pub enum Server {
     V1(v1::Server),
     V2(v2::Server),
     V3(v3::Server),
+}
+
+impl Server {
+    pub fn add_group(&self, state: def::GroupState) -> windows::core::Result<Group> {
+        let mut state = state;
+
+        match self {
+            Self::V1(server) => Ok(Group::V1(server.add_group(
+                &state.name,
+                state.active,
+                state.client_handle,
+                state.update_rate,
+                state.locale_id,
+                state.time_bias,
+                state.percent_deadband,
+                &mut state.update_rate,
+                &mut state.server_handle,
+            )?)),
+            Self::V2(server) => Ok(Group::V2(server.add_group(
+                &state.name,
+                state.active,
+                state.client_handle,
+                state.update_rate,
+                state.locale_id,
+                state.time_bias,
+                state.percent_deadband,
+                &mut state.update_rate,
+                &mut state.server_handle,
+            )?)),
+            Self::V3(server) => Ok(Group::V3(server.add_group(
+                &state.name,
+                state.active,
+                state.client_handle,
+                state.update_rate,
+                state.locale_id,
+                state.time_bias,
+                state.percent_deadband,
+                &mut state.update_rate,
+                &mut state.server_handle,
+            )?)),
+        }
+    }
+
+    pub fn get_status(&self) -> windows::core::Result<def::ServerStatus> {
+        let status = match self {
+            Self::V1(server) => server.get_status(),
+            Self::V2(server) => server.get_status(),
+            Self::V3(server) => server.get_status(),
+        }?;
+
+        def::ServerStatus::try_from_native(status.as_result()?)
+    }
+
+    pub fn remove_group(&self, server_handle: u32, force: bool) -> windows::core::Result<()> {
+        match self {
+            Self::V1(server) => server.remove_group(server_handle, force),
+            Self::V2(server) => server.remove_group(server_handle, force),
+            Self::V3(server) => server.remove_group(server_handle, force),
+        }
+    }
+
+    pub fn create_group_enumerator(&self, scope: i32) -> windows::core::Result<GroupIterator> {
+        let iterator = match self {
+            Self::V1(server) => GroupIterator::V1(
+                server.create_group_enumerator(opc_da_bindings::tagOPCENUMSCOPE(scope))?,
+            ),
+            Self::V2(server) => GroupIterator::V2(
+                server.create_group_enumerator(opc_da_bindings::tagOPCENUMSCOPE(scope))?,
+            ),
+            Self::V3(server) => GroupIterator::V3(
+                server.create_group_enumerator(opc_da_bindings::tagOPCENUMSCOPE(scope))?,
+            ),
+        };
+
+        Ok(iterator)
+    }
+}
+
+impl From<v1::Server> for Server {
+    fn from(server: v1::Server) -> Self {
+        Self::V1(server)
+    }
+}
+
+impl From<v2::Server> for Server {
+    fn from(server: v2::Server) -> Self {
+        Self::V2(server)
+    }
+}
+
+impl From<v3::Server> for Server {
+    fn from(server: v3::Server) -> Self {
+        Self::V3(server)
+    }
+}
+
+pub enum GroupIterator {
+    V1(v1::GroupIterator),
+    V2(v2::GroupIterator),
+    V3(v3::GroupIterator),
 }

--- a/opc_da/src/client/unified/server.rs
+++ b/opc_da/src/client/unified/server.rs
@@ -1,6 +1,6 @@
 use crate::{
     client::{v1, v2, v3, ServerTrait as _},
-    def::{self, TryFromNative},
+    def::{self, ToNative as _, TryFromNative as _},
 };
 
 use super::Group;
@@ -70,17 +70,16 @@ impl Server {
         }
     }
 
-    pub fn create_group_enumerator(&self, scope: i32) -> windows::core::Result<GroupIterator> {
+    pub fn create_group_enumerator(
+        &self,
+        scope: def::EnumScope,
+    ) -> windows::core::Result<GroupIterator> {
+        let scope = scope.to_native();
+
         let iterator = match self {
-            Self::V1(server) => GroupIterator::V1(
-                server.create_group_enumerator(opc_da_bindings::tagOPCENUMSCOPE(scope))?,
-            ),
-            Self::V2(server) => GroupIterator::V2(
-                server.create_group_enumerator(opc_da_bindings::tagOPCENUMSCOPE(scope))?,
-            ),
-            Self::V3(server) => GroupIterator::V3(
-                server.create_group_enumerator(opc_da_bindings::tagOPCENUMSCOPE(scope))?,
-            ),
+            Self::V1(server) => GroupIterator::V1(server.create_group_enumerator(scope)?),
+            Self::V2(server) => GroupIterator::V2(server.create_group_enumerator(scope)?),
+            Self::V3(server) => GroupIterator::V3(server.create_group_enumerator(scope)?),
         };
 
         Ok(iterator)

--- a/opc_da/src/client/v1/mod.rs
+++ b/opc_da/src/client/v1/mod.rs
@@ -14,6 +14,7 @@ use super::{
 };
 
 /// Client for OPC DA 1.0 servers.
+#[derive(Debug)]
 pub struct Client;
 
 impl ClientTrait<Server> for Client {

--- a/opc_da/src/client/v1/mod.rs
+++ b/opc_da/src/client/v1/mod.rs
@@ -80,6 +80,9 @@ impl BrowseServerAddressSpaceTrait for Server {
     }
 }
 
+/// Iterator over OPC DA 1.0 groups.
+pub type GroupIterator = super::GroupIterator<Group>;
+
 /// An OPC DA 1.0 group implementation.
 ///
 /// Provides access to OPC DA 1.0 group interfaces including:

--- a/opc_da/src/client/v1/mod.rs
+++ b/opc_da/src/client/v1/mod.rs
@@ -5,17 +5,27 @@
 
 use windows::core::Interface as _;
 
-use super::traits::{
-    AsyncIoTrait, BrowseServerAddressSpaceTrait, DataObjectTrait, GroupStateMgtTrait, ItemMgtTrait,
-    PublicGroupStateMgtTrait, ServerPublicGroupsTrait, ServerTrait, SyncIoTrait,
+use super::{
+    traits::{
+        AsyncIoTrait, BrowseServerAddressSpaceTrait, DataObjectTrait, GroupStateMgtTrait,
+        ItemMgtTrait, PublicGroupStateMgtTrait, ServerPublicGroupsTrait, ServerTrait, SyncIoTrait,
+    },
+    ClientTrait,
 };
+
+/// Client for OPC DA 1.0 servers.
+pub struct Client;
+
+impl ClientTrait<Server> for Client {
+    const CATALOG_ID: windows::core::GUID = opc_da_bindings::CATID_OPCDAServer10::IID;
+}
 
 /// An OPC DA 1.0 server implementation.
 ///
 /// Provides access to OPC DA 1.0 server interfaces including:
-/// - IOPCServer for basic server operations
-/// - IOPCServerPublicGroups for public group management
-/// - IOPCBrowseServerAddressSpace for browsing the address space
+/// - `IOPCServer` for basic server operations
+/// - `IOPCServerPublicGroups` for public group management
+/// - `IOPCBrowseServerAddressSpace` for browsing the address space
 ///
 /// # Example
 /// ```no_run
@@ -45,10 +55,6 @@ impl ServerTrait<Group> for Server {
     fn interface(&self) -> windows::core::Result<&opc_da_bindings::IOPCServer> {
         Ok(&self.server)
     }
-
-    fn create_group(&self, unknown: windows::core::IUnknown) -> windows::core::Result<Group> {
-        unknown.try_into()
-    }
 }
 
 impl ServerPublicGroupsTrait for Server {
@@ -76,12 +82,12 @@ impl BrowseServerAddressSpaceTrait for Server {
 /// An OPC DA 1.0 group implementation.
 ///
 /// Provides access to OPC DA 1.0 group interfaces including:
-/// - IOPCItemMgt for item management
-/// - IOPCGroupStateMgt for group state management
-/// - IOPCPublicGroupStateMgt for public group operations
-/// - IOPCSyncIO for synchronous operations
-/// - IOPCAsyncIO for asynchronous operations
-/// - IDataObject for data transfer
+/// - `IOPCItemMgt` for item management
+/// - `IOPCGroupStateMgt` for group state management
+/// - `IOPCPublicGroupStateMgt` for public group operations
+/// - `IOPCSyncIO` for synchronous operations
+/// - `IOPCAsyncIO` for asynchronous operations
+/// - `IDataObject` for data transfer
 pub struct Group {
     pub(crate) item_mgt: opc_da_bindings::IOPCItemMgt,
     pub(crate) group_state_mgt: opc_da_bindings::IOPCGroupStateMgt,

--- a/opc_da/src/client/v2/mod.rs
+++ b/opc_da/src/client/v2/mod.rs
@@ -5,21 +5,31 @@
 
 use windows::core::Interface as _;
 
-use super::traits::{
-    AsyncIo2Trait, AsyncIoTrait, BrowseServerAddressSpaceTrait, CommonTrait,
-    ConnectionPointContainerTrait, DataObjectTrait, GroupStateMgtTrait, ItemMgtTrait,
-    ItemPropertiesTrait, PublicGroupStateMgtTrait, ServerPublicGroupsTrait, ServerTrait,
-    SyncIoTrait,
+use super::{
+    traits::{
+        AsyncIo2Trait, AsyncIoTrait, BrowseServerAddressSpaceTrait, CommonTrait,
+        ConnectionPointContainerTrait, DataObjectTrait, GroupStateMgtTrait, ItemMgtTrait,
+        ItemPropertiesTrait, PublicGroupStateMgtTrait, ServerPublicGroupsTrait, ServerTrait,
+        SyncIoTrait,
+    },
+    ClientTrait,
 };
+
+/// Client for OPC DA 2.0 servers.
+pub struct Client;
+
+impl ClientTrait<Server> for Client {
+    const CATALOG_ID: windows::core::GUID = opc_da_bindings::CATID_OPCDAServer20::IID;
+}
 
 /// An OPC DA 2.0 server implementation.
 ///
 /// Provides access to OPC DA 2.0 server interfaces including:
-/// - IOPCServer for basic server operations
-/// - IOPCCommon for server status and locale management
-/// - IOPCItemProperties for browsing item properties
-/// - IOPCServerPublicGroups for public group management
-/// - IOPCBrowseServerAddressSpace for browsing the address space
+/// - `IOPCServer` for basic server operations
+/// - `IOPCCommon` for server status and locale management
+/// - `IOPCItemProperties` for browsing item properties
+/// - `IOPCServerPublicGroups` for public group management
+/// - `IOPCBrowseServerAddressSpace` for browsing the address space
 ///
 /// # Example
 /// ```no_run
@@ -54,10 +64,6 @@ impl TryFrom<windows::core::IUnknown> for Server {
 impl ServerTrait<Group> for Server {
     fn interface(&self) -> windows::core::Result<&opc_da_bindings::IOPCServer> {
         Ok(&self.server)
-    }
-
-    fn create_group(&self, unknown: windows::core::IUnknown) -> windows::core::Result<Group> {
-        unknown.try_into()
     }
 }
 
@@ -106,12 +112,12 @@ impl BrowseServerAddressSpaceTrait for Server {
 /// An OPC DA 2.0 group implementation.
 ///
 /// Provides access to OPC DA 2.0 group interfaces including:
-/// - IOPCItemMgt for item management
-/// - IOPCGroupStateMgt for group state management
-/// - IOPCPublicGroupStateMgt for public group operations
-/// - IOPCSyncIO for synchronous operations
-/// - IOPCAsyncIO/2 for asynchronous operations
-/// - IDataObject for data transfer
+/// - `IOPCItemMgt` for item management
+/// - `IOPCGroupStateMgt` for group state management
+/// - `IOPCPublicGroupStateMgt` for public group operations
+/// - `IOPCSyncIO` for synchronous operations
+/// - `IOPCAsyncIO` and `IOPCAsyncIO2` for asynchronous operations
+/// - `IDataObject` for data transfer
 pub struct Group {
     pub(crate) item_mgt: opc_da_bindings::IOPCItemMgt,
     pub(crate) group_state_mgt: opc_da_bindings::IOPCGroupStateMgt,

--- a/opc_da/src/client/v2/mod.rs
+++ b/opc_da/src/client/v2/mod.rs
@@ -16,6 +16,7 @@ use super::{
 };
 
 /// Client for OPC DA 2.0 servers.
+#[derive(Debug)]
 pub struct Client;
 
 impl ClientTrait<Server> for Client {

--- a/opc_da/src/client/v2/mod.rs
+++ b/opc_da/src/client/v2/mod.rs
@@ -110,6 +110,9 @@ impl BrowseServerAddressSpaceTrait for Server {
     }
 }
 
+/// Iterator over OPC DA 2.0 groups.
+pub type GroupIterator = super::GroupIterator<Group>;
+
 /// An OPC DA 2.0 group implementation.
 ///
 /// Provides access to OPC DA 2.0 group interfaces including:

--- a/opc_da/src/client/v3/mod.rs
+++ b/opc_da/src/client/v3/mod.rs
@@ -5,19 +5,29 @@
 
 use windows::core::Interface as _;
 
-use super::traits::{
-    AsyncIo2Trait, AsyncIo3Trait, BrowseTrait, CommonTrait, ConnectionPointContainerTrait,
-    GroupStateMgt2Trait, GroupStateMgtTrait, ItemDeadbandMgtTrait, ItemIoTrait, ItemMgtTrait,
-    ItemSamplingMgtTrait, ServerTrait, SyncIo2Trait, SyncIoTrait,
+use super::{
+    traits::{
+        AsyncIo2Trait, AsyncIo3Trait, BrowseTrait, CommonTrait, ConnectionPointContainerTrait,
+        GroupStateMgt2Trait, GroupStateMgtTrait, ItemDeadbandMgtTrait, ItemIoTrait, ItemMgtTrait,
+        ItemSamplingMgtTrait, ServerTrait, SyncIo2Trait, SyncIoTrait,
+    },
+    ClientTrait,
 };
+
+/// Client for OPC DA 3.0 servers.
+pub struct Client;
+
+impl ClientTrait<Server> for Client {
+    const CATALOG_ID: windows::core::GUID = opc_da_bindings::CATID_OPCDAServer30::IID;
+}
 
 /// An OPC DA 3.0 server implementation.
 ///
 /// Provides access to OPC DA 3.0 server interfaces including:
-/// - IOPCServer for basic server operations
-/// - IOPCCommon for server status and locale management
-/// - IOPCBrowse for browsing the server address space
-/// - IOPCItemIO for direct item read/write operations
+/// - `IOPCServer` for basic server operations
+/// - `IOPCCommon` for server status and locale management
+/// - `IOPCBrowse` for browsing the server address space
+/// - `IOPCItemIO` for direct item read/write operations
 ///
 /// # Example
 /// ```no_run
@@ -51,10 +61,6 @@ impl ServerTrait<Group> for Server {
     fn interface(&self) -> windows::core::Result<&opc_da_bindings::IOPCServer> {
         Ok(&self.server)
     }
-
-    fn create_group(&self, unknown: windows::core::IUnknown) -> windows::core::Result<Group> {
-        unknown.try_into()
-    }
 }
 
 impl CommonTrait for Server {
@@ -86,12 +92,12 @@ impl ItemIoTrait for Server {
 /// An OPC DA 3.0 group implementation.
 ///
 /// Provides access to OPC DA 3.0 group interfaces including:
-/// - IOPCItemMgt for item management
-/// - IOPCGroupStateMgt/2 for group state management
-/// - IOPCSyncIO/2 for synchronous operations
-/// - IOPCAsyncIO2/3 for asynchronous operations
-/// - IOPCItemSamplingMgt for item sampling control
-/// - IOPCItemDeadbandMgt for deadband management
+/// - `IOPCItemMgt` for item management
+/// - `IOPCGroupStateMgt` and `IOPCGroupStateMgt2` for group state management
+/// - `IOPCSyncIO` and `IOPCSyncIO2` for synchronous operations
+/// - `IOPCAsyncIO2` and `IOPCAsyncIO3` for asynchronous operations
+/// - `IOPCItemSamplingMgt` for item sampling control
+/// - `IOPCItemDeadbandMgt` for deadband management
 #[derive(Debug)]
 pub struct Group {
     pub(crate) item_mgt: opc_da_bindings::IOPCItemMgt,

--- a/opc_da/src/client/v3/mod.rs
+++ b/opc_da/src/client/v3/mod.rs
@@ -15,6 +15,7 @@ use super::{
 };
 
 /// Client for OPC DA 3.0 servers.
+#[derive(Debug)]
 pub struct Client;
 
 impl ClientTrait<Server> for Client {

--- a/opc_da/src/client/v3/mod.rs
+++ b/opc_da/src/client/v3/mod.rs
@@ -90,6 +90,9 @@ impl ItemIoTrait for Server {
     }
 }
 
+/// Iterator over OPC DA 3.0 groups.
+pub type GroupIterator = super::GroupIterator<Group>;
+
 /// An OPC DA 3.0 group implementation.
 ///
 /// Provides access to OPC DA 3.0 group interfaces including:

--- a/opc_da/src/def.rs
+++ b/opc_da/src/def.rs
@@ -291,7 +291,10 @@ impl TryFromNative for ServerState {
             opc_da_bindings::OPC_STATUS_SUSPENDED => Ok(ServerState::Suspended),
             opc_da_bindings::OPC_STATUS_TEST => Ok(ServerState::Test),
             opc_da_bindings::OPC_STATUS_COMM_FAULT => Ok(ServerState::CommunicationFault),
-            _ => unreachable!(),
+            unknown => Err(windows::core::Error::new(
+                windows::Win32::Foundation::E_INVALIDARG,
+                format!("Unknown server state: {:?}", unknown),
+            )),
         }
     }
 }
@@ -332,9 +335,9 @@ impl TryFromNative for EnumScope {
             opc_da_bindings::OPC_ENUM_PUBLIC => Ok(EnumScope::Public),
             opc_da_bindings::OPC_ENUM_PRIVATE => Ok(EnumScope::Private),
             opc_da_bindings::OPC_ENUM_ALL => Ok(EnumScope::All),
-            _ => Err(windows::core::Error::new(
+            unknown => Err(windows::core::Error::new(
                 windows::Win32::Foundation::E_INVALIDARG,
-                "Invalid EnumScope",
+                format!("Unknown enum scope: {:?}", unknown),
             )),
         }
     }

--- a/opc_da/src/server/com/base/basic.rs
+++ b/opc_da/src/server/com/base/basic.rs
@@ -3,14 +3,11 @@ use super::variant::Variant;
 #[derive(Clone, Default)]
 pub struct Quality(pub u16);
 
-#[derive(Clone)]
-pub struct SystemTime(pub std::time::SystemTime);
-
 #[derive(Default)]
 pub struct Value {
     pub variant: Variant,
     pub quality: Quality,
-    pub timestamp: Option<SystemTime>,
+    pub timestamp: Option<std::time::SystemTime>,
 }
 
 #[derive(Default)]

--- a/opc_da/src/server/com/server.rs
+++ b/opc_da/src/server/com/server.rs
@@ -1,4 +1,7 @@
-use crate::server::traits::{ItemOptionalVqt, ItemWithMaxAge, ServerTrait};
+use crate::{
+    def::{TryFromNative, TryToNative},
+    server::traits::{ItemOptionalVqt, ItemWithMaxAge, ServerTrait},
+};
 
 use super::{
     enumeration::{ConnectionPointsEnumerator, StringEnumerator},
@@ -110,7 +113,7 @@ impl<T: ServerTrait + 'static> opc_da_bindings::IOPCServer_Impl for Server_Impl<
         reference_interface_id: *const windows::core::GUID,
     ) -> windows::core::Result<windows::core::IUnknown> {
         self.create_group_enumerator(
-            scope.try_into()?,
+            TryFromNative::try_from_native(&scope)?,
             unsafe { reference_interface_id.as_ref() }.map(|id| id.to_u128()),
         )
     }
@@ -509,8 +512,8 @@ impl<T: ServerTrait + 'static> opc_da_bindings::IOPCItemIO_Impl for Server_Impl<
         PointerWriter::try_write_array_pointer(
             &result
                 .iter()
-                .map(|vqt| vqt.timestamp.clone().into())
-                .collect::<Vec<_>>(),
+                .map(|vqt| vqt.timestamp.try_to_native())
+                .collect::<windows::core::Result<Vec<_>>>()?,
             timestamps,
         )?;
 

--- a/opc_da/src/server/com/variant.rs
+++ b/opc_da/src/server/com/variant.rs
@@ -1,10 +1,10 @@
 use windows::core::{BSTR, VARIANT};
 use windows::Win32::{
-    Foundation::{FILETIME, VARIANT_BOOL, VARIANT_TRUE},
+    Foundation::{VARIANT_BOOL, VARIANT_TRUE},
     System::Variant::VARENUM,
 };
 
-use super::base::{AccessRight, Quality, SystemTime, Variant};
+use super::base::{AccessRight, Quality, Variant};
 
 use opc_da_bindings;
 
@@ -107,24 +107,5 @@ impl From<VARIANT> for Variant {
 impl From<windows::core::imp::VARIANT> for Variant {
     fn from(value: windows::core::imp::VARIANT) -> Self {
         unsafe { Variant::from(VARIANT::from_raw(value)) }
-    }
-}
-
-impl From<SystemTime> for FILETIME {
-    fn from(val: SystemTime) -> Self {
-        let duration = val.0.duration_since(std::time::UNIX_EPOCH).unwrap();
-        let intervals = duration.as_secs() * 10_000_000 + duration.subsec_nanos() as u64 / 100;
-        FILETIME {
-            dwLowDateTime: intervals as u32,
-            dwHighDateTime: (intervals >> 32) as u32,
-        }
-    }
-}
-
-impl From<FILETIME> for SystemTime {
-    fn from(value: FILETIME) -> Self {
-        let intervals = (value.dwLowDateTime as u64) | ((value.dwHighDateTime as u64) << 32);
-        let duration = core::time::Duration::from_nanos(intervals * 100);
-        SystemTime(std::time::UNIX_EPOCH + duration)
     }
 }

--- a/opc_da/src/server/traits/server.rs
+++ b/opc_da/src/server/traits/server.rs
@@ -1,3 +1,5 @@
+use crate::def;
+
 use super::def::*;
 
 /// Server trait
@@ -193,8 +195,10 @@ pub trait ServerTrait {
 
     fn query_organization(&self) -> windows::core::Result<NamespaceType>;
 
-    fn change_browse_position(&self, browse_direction: BrowseDirection)
-        -> windows::core::Result<()>;
+    fn change_browse_position(
+        &self,
+        browse_direction: BrowseDirection,
+    ) -> windows::core::Result<()>;
 
     fn browse_opc_item_ids(
         &self,
@@ -236,13 +240,13 @@ pub trait ServerTrait {
         reference_interface_id: Option<u128>,
     ) -> windows::core::Result<windows::core::IUnknown>;
 
-    fn get_status(&self) -> windows::core::Result<ServerStatus>;
+    fn get_status(&self) -> windows::core::Result<def::ServerStatus>;
 
     fn remove_group(&self, server_group: u32, force: bool) -> windows::core::Result<()>;
 
     fn create_group_enumerator(
         &self,
-        scope: EnumScope,
+        scope: def::EnumScope,
         reference_interface_id: Option<u128>,
     ) -> windows::core::Result<windows::core::IUnknown>;
 }


### PR DESCRIPTION
…oup creation, and enhance server interaction methods

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced `Client` structs for OPC DA 1.0, 2.0, and 3.0, providing new entry points for server interactions.
	- Added `ClientTrait` for enhanced client functionality, including methods for server retrieval and creation.
	- Implemented new memory management utilities to improve safety and usability.
	- Added new methods for managing groups and server statuses within the `Server` enum.
	- Introduced `GroupIterator` for iterating over groups in a more structured manner.

- **Bug Fixes**
	- Updated pointer and memory management methods for clarity and safety.
	- Enhanced error handling in various methods to improve robustness.

- **Documentation**
	- Improved documentation for structs and methods, enhancing clarity and usability.

- **Refactor**
	- Removed `create_group` method from `ServerTrait`, altering group management approach.
	- Updated module structure to restore previously removed modules and enhance organization.
	- Enhanced the `Group` enum with `From` trait implementations for better interoperability.
	- Streamlined handling of time-related types and server status across the codebase.
	- Changed parameter names in several methods for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->